### PR TITLE
[wip] Work around PHPUnit on travis requiring phpenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ php:
   - 5.4
   - 5.3
 before_script:
-  - composer install --dev --dev --prefer-source --no-interaction
+  - composer install --dev --prefer-source --no-interaction
+  - wget https://phar.phpunit.de/phpunit.phar
 script:
-  - phpunit=`which phpunit`
-  - sudo $phpunit --coverage-text
+  - php=~/.phpenv/versions/$(phpenv version-name)/bin/php
+  - sudo $php phpunit.phar --coverage-text


### PR DESCRIPTION
Current build errors on travis are caused by an issue in travis and ought to be ignored for now:
https://github.com/travis-ci/travis-ci/issues/2261

This PR _could_ work around the changes, but I'm not particularly fond of it.

Travis uses phpenv to configure multiple php versions. We have to run
PHPUnit as root in order to test raw sockets, and phpenv is only
installed / configured for the default user.
