### PR TITLE
Expose socket_read type parameter

### DIFF
--- a/src/Socket.php
+++ b/src/Socket.php
@@ -232,14 +232,15 @@ class Socket
      * read up to $length bytes from connect()ed / accept()ed socket
      *
      * @param int $length maximum length to read
+     * @param int $type
      * @return string
      * @throws Exception on error
      * @see self::recv() if you need to pass flags
      * @uses socket_read()
      */
-    public function read($length)
+    public function read($length, $type = PHP_BINARY_READ)
     {
-        $data = @socket_read($this->resource, $length);
+        $data = @socket_read($this->resource, $length, $type);
         if ($data === false) {
             throw Exception::createFromSocketResource($this->resource);
         }


### PR DESCRIPTION
You can pass the third parameter to socket_read (binary or text read)