### PR TITLE
Return the byte length of data from socket_recv* functions

### DIFF
--- a/src/Socket.php
+++ b/src/Socket.php
@@ -255,19 +255,20 @@ class Socket
      *
      * @param int $length maximum length to read
      * @param int $flags
-     * @return string
+     * @param string $buffer reference will be filled with the remote data
+     * @return int the byte length of the the data received
      * @throws Exception on error
      * @see self::read() if you do not need to pass $flags
      * @see self::recvFrom() if your socket is not connect()ed
      * @uses socket_recv()
      */
-    public function recv($length, $flags)
+    public function recv($length, $flags, &$buffer)
     {
         $ret = @socket_recv($this->resource, $buffer, $length, $flags);
         if ($ret === false) {
             throw Exception::createFromSocketResource($this->resource);
         }
-        return $buffer;
+        return $ret;
     }
 
     /**
@@ -276,19 +277,20 @@ class Socket
      * @param int    $length maximum length to read
      * @param int    $flags
      * @param string $remote reference will be filled with remote/peer address/path
-     * @return string
+     * @param string $buffer reference will be filled with the remote data
+     * @return int the byte length of the the data received
      * @throws Exception on error
      * @see self::recv() if your socket is connect()ed
      * @uses socket_recvfrom()
      */
-    public function recvFrom($length, $flags, &$remote)
+    public function recvFrom($length, $flags, &$remote, &$buffer)
     {
         $ret = @socket_recvfrom($this->resource, $buffer, $length, $flags, $address, $port);
         if ($ret === false) {
             throw Exception::createFromSocketResource($this->resource);
         }
         $remote = $this->formatAddress($address, $port);
-        return $buffer;
+        return $ret;
     }
 
     /**


### PR DESCRIPTION
This would fix issue #21 by returning the byte length as the return value and the data by reference.