### PR TITLE
Added phpunit to composer dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
   - composer install --prefer-source --no-interaction
 
 script:
-  - phpunit --coverage-text
+  - vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,8 @@
     "require": {
         "ext-sockets": "*",
         "php": ">=5.3"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8 || ^5.2"
     }
 }


### PR DESCRIPTION
I am keen to start contributing as I'm about to begin using this library for a project I'm working on.

I don't have phpunit installed globally and since it now supports being installed with composer, I've added it as a dev dependency to make it easier to run the tests in this project.