### PR TITLE
IPv6 tests are now skipped on Travis CI

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Socket\Raw;
+
+class Environment
+{
+    /**
+     * Does the current runtime environment support IPv6?
+     *
+     * @return bool
+     */
+    public function supportsIPv6()
+    {
+        if (!$this->compiledWithIPv6Support()) {
+            return false;
+        }
+
+        if ($this->runningOnTravisCI()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Does the current runtime environment support UNIX + UDG sockets?
+     *
+     * @return bool
+     */
+    public function supportsUnixSockets()
+    {
+        // TODO: check this check
+        return defined('AF_UNIX');
+    }
+
+    /**
+     * Has IPv6 support been enabled in this runtime?
+     *
+     * @return bool
+     */
+    private function compiledWithIPv6Support()
+    {
+        // TODO: check this check
+        return defined('AF_INET6');
+    }
+
+    /**
+     * Are we running on Travis CI?
+     * They currently do not support IPv6 (https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future)
+     *
+     * @return bool
+     */
+    private function runningOnTravisCI()
+    {
+        return getenv('TRAVIS') == 'true';
+    }
+}

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Socket\Raw\Environment;
 use Socket\Raw\Factory;
 use Socket\Raw\Socket;
 
@@ -13,23 +14,28 @@ class FactoryTest extends PHPUnit_Framework_TestCase{
      */
     protected $factory;
 
+    /**
+     * @var Socket\Raw\Environment
+     * @type Environment
+     */
+    protected $environment;
+
     public function setUp()
     {
         $this->factory = new Factory();
+        $this->environment = new Environment();
     }
 
     public function testSupportsIpv6()
     {
-        // TODO: check this check
-        if (!defined('AF_INET6')) {
+        if (!$this->environment->supportsIPv6()) {
             $this->markTestSkipped('This system does not seem to support IPv6 sockets / addressing');
         }
     }
 
     public function testSupportsUnix()
     {
-        // TODO: check this check
-        if (!defined('AF_UNIX')) {
+        if (!$this->environment->supportsUnixSockets()) {
             $this->markTestSkipped('This system does not seem to support UNIX and UDG sockets');
         }
     }


### PR DESCRIPTION
Should fix #25 

I've pulled the environment tests (unix + ipv6) into their own object and used this inside the Factory tests.

If this is merged, should we utilise the new Environment object inside the Factory itself? For instance, throwing a custom exception inside createTcp6() with a nice message stating that IPv6 support is not available.

I've left the TODO markers next to their respective checks - what can be done to test these checks thoroughly