### PR TITLE
Update Travis configuration to fix IPv6 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: php
+
 php:
   - 5.4
   - 5.3
   - hhvm
-before_script:
-  - composer install --dev --dev --prefer-source --no-interaction
+
+sudo: false
+
+install:
+  - composer install --prefer-source --no-interaction
+
 script:
-  - phpunit=`which phpunit`
-  - sudo $phpunit --coverage-text || ([[ $? = 139 ]] && echo && echo "Ignoring SEGFAULT.." >&2)
+  - phpunit --coverage-text


### PR DESCRIPTION
Now uses Travis' container infrastructure in order to restore IPv6 support.

The container infrastructure does not support root access, so we now have to skip raw/ICMP tests.

Closes #25 
Supersedes/closes #27