### PR TITLE
Add $timeout parameter for Factory::createClient()

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ $factory = new \Socket\Raw\Factory();
 
 #### createClient()
 
-The `createClient($address)` method is the most convenient method for creating connected client sockets
+The `createClient(string $address, null|float $timeout): Socket` method is
+the most convenient method for creating connected client sockets
 (similar to how [`fsockopen()`](http://www.php.net/manual/en/function.fsockopen.php) or
 [`stream_socket_client()`](http://www.php.net/manual/en/function.stream-socket-client.php) work).
 
@@ -83,6 +84,9 @@ $socket = $factory->createClient('tcp://www.google.com:80');
 
 // same as above, as scheme defaults to TCP
 $socket = $factory->createClient('www.google.com:80');
+
+// same as above, but wait no longer than 2.5s for connection
+$socket = $factory->createClient('www.google.com:80', 2.5);
 
 // create connectionless UDP/IP datagram socket connected to google's DNS
 $socket = $factory->createClient('udp://8.8.8.8:53');

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -9,19 +9,27 @@ class Factory
     /**
      * create client socket connected to given target address
      *
-     * @param string $address target address to connect to
+     * @param string     $address target address to connect to
+     * @param null|float $timeout connection timeout (in seconds), default null = no limit
      * @return \Socket\Raw\Socket
      * @throws InvalidArgumentException if given address is invalid
      * @throws Exception on error
      * @uses self::createFromString()
      * @uses Socket::connect()
+     * @uses Socket::connectTimeout()
      */
-    public function createClient($address)
+    public function createClient($address, $timeout = null)
     {
         $socket = $this->createFromString($address, $scheme);
 
         try {
-            $socket->connect($address);
+            if ($timeout === null) {
+                $socket->connect($address);
+            } else {
+                // connectTimeout enables non-blocking mode, so turn blocking on again
+                $socket->connectTimeout($address, $timeout);
+                $socket->setBlocking(true);
+            }
         }
         catch (Exception $e) {
             $socket->close();

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -62,6 +62,21 @@ class FactoryTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Socket\Raw\Socket', $socket);
     }
 
+    /** @group internet */
+    public function testCreateClientWithReasonableTimeoutShouldSuccess()
+    {
+        $socket = $this->factory->createClient('www.google.com:80', 5.0);
+
+        $this->assertInstanceOf('Socket\Raw\Socket', $socket);
+    }
+
+    /** @group internet */
+    public function testCreateClientWithSmallTimeoutToUnboundPortTimesOut()
+    {
+        $this->setExpectedException('Socket\Raw\Exception', null, SOCKET_ETIMEDOUT);
+        $this->factory->createClient('www.google.com:81', 0.001);
+    }
+
     /**
      * the target address should not be bound, so connecting via TCP should fail
      *


### PR DESCRIPTION
This PR adds a new `$timeout` parameter for the `Factory::createClient()` method.

```php
// connect to Google, but wait no longer than 2.5s for connection
 $socket = $factory->createClient('www.google.com:80', 2.5);
```

This cherry-picks some of the suggested changes from #17 with proper attribution and adds some documentation and tests. Thanks to @Elbandi for the original PR!

Resolves / closes #7 
Supersedes / closes #17 