### PR TITLE
Improve Windows support (async connections and Unix domain sockets)

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -30,8 +30,7 @@ class Factory
                 $socket->connectTimeout($address, $timeout);
                 $socket->setBlocking(true);
             }
-        }
-        catch (Exception $e) {
+        } catch (Exception $e) {
             $socket->close();
             throw $e;
         }
@@ -59,8 +58,7 @@ class Factory
             if ($socket->getType() === SOCK_STREAM) {
                 $socket->listen();
             }
-        }
-        catch (Exception $e) {
+        } catch (Exception $e) {
             $socket->close();
             throw $e;
         }

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -141,10 +141,9 @@ class Socket
 
             // socket is already connected immediately?
             return $this;
-        }
-        catch (Exception $e) {
-            // non-blocking connect() should be EINPROGRESS => otherwise re-throw
-            if ($e->getCode() !== SOCKET_EINPROGRESS) {
+        } catch (Exception $e) {
+            // non-blocking connect() should be EINPROGRESS (or EWOULDBLOCK on Windows) => otherwise re-throw
+            if ($e->getCode() !== SOCKET_EINPROGRESS && $e->getCode() !== SOCKET_EWOULDBLOCK) {
                 throw $e;
             }
 


### PR DESCRIPTION
This PR adds Windows support checking for known error conditions on Windows. This has been tested extensively on some Windows 10 installations, but this repository does not currently run any tests on Windows. I consider this to be out of scope for this ticket, but agree that it makes sense to look into test automation in a follow-up PR. In the meantime, you're invited to run this on your local Windows installation or take my word for granted, so now let's get this shipped! :shipit: :heart: 

For more details about support for Unix domain sockets, see also
https://blogs.msdn.microsoft.com/commandline/2017/12/19/af_unix-comes-to-windows/

Resolves / closes #41 
Refs https://github.com/reactphp/child-process/pull/67