### PR TITLE
suppress warning error logs for assertAlive

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -65,6 +65,10 @@ class Exception extends RuntimeException
      */
     protected static function getErrorMessage($code)
     {
+        if (null === $code || false === $code) {
+            return 'not a valid resource';
+        }
+        
         $string = socket_strerror($code);
 
         // search constant starting with SOCKET_ for this error code

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -474,7 +474,11 @@ class Socket
      */
     public function assertAlive()
     {
-        $code = $this->getOption(SOL_SOCKET, SO_ERROR);
+        if (is_resource($this->resource)) {
+            $code = $this->getOption(SOL_SOCKET, SO_ERROR);
+        } else {
+            $code = false;
+        }
         if ($code !== 0) {
             throw Exception::createFromCode($code, 'Socket error');
         }

--- a/tests/SocketTest.php
+++ b/tests/SocketTest.php
@@ -267,4 +267,25 @@ class SocketTest extends TestCase
             parent::setExpectedException($exception, $message, $code);
         }
     }
+
+    /**
+     * @depends testServerNonBlocking
+     */
+    public function testAssertAliveAfterClose(Socket $server)
+    {
+        $errorHandlerCalled = false;
+        try {
+            set_error_handler(function() use (&$errorHandlerCalled) {
+                $errorHandlerCalled = func_get_args();
+            });
+            $server->close();
+            $server->assertAlive();
+        } catch (Exception $e) {
+            $this->assertFalse($errorHandlerCalled, 'we do not want to trigger any warnings etc.');
+            $this->assertSame(0, $e->getCode());
+            $this->assertSame('Socket error: not a valid resource', $e->getMessage());
+        } finally {
+            restore_error_handler();
+        }
+    }
 }


### PR DESCRIPTION
with a third party library (https://github.com/jonjomckay/quahog) we get this stack trace:

vendor/sentry/sentry/lib/Raven/ErrorHandler.php in socket_last_error
vendor/clue/socket-raw/src/Exception.php in createFromSocketResource at line 21
vendor/clue/socket-raw/src/Socket.php in getOption at line 176
vendor/clue/socket-raw/src/Socket.php in assertAlive at line 478

it is a E_WARNING caused by assertAlive() socket operation on an invalid resource. Added error handling code to avoid raising E_WARNINGs in assertAlive()