### PR TITLE
Run tests on PHPUnit 9 and update PHPUnit configuration schema for PHPUnit 9.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/examples/ export-ignore
+/phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
+/tests/ export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 # lock distro so new future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
@@ -16,7 +16,7 @@ matrix:
     - php: 7.3
     - php: 7.4
     - php: hhvm-3.18
-      install: composer require phpunit/phpunit:^5 --dev --no-interaction
+      install: composer require phpunit/phpunit:^5 --dev
     - name: "Windows"
       os: windows
       language: shell # no built-in php support
@@ -30,10 +30,9 @@ matrix:
     - php: hhvm-3.18
     - os: windows
 
-sudo: false
-
 install:
-  - composer install --no-interaction
+  - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
         "php": ">=5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^6.0 || ^5.2 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php"
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
->
+         cacheResult="false">
     <testsuites>
         <testsuite name="Socket Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Socket Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -12,7 +12,10 @@ class FactoryTest extends TestCase
      */
     protected $factory;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpFactory()
     {
         $this->factory = new Factory();
     }
@@ -409,13 +412,13 @@ class FactoryTest extends TestCase
      *
      * @param Socket $socket
      * @depends testCreateListenRandom
-     * @expectedException Exception
      */
     public function testCreateListenInUseFails(Socket $socket)
     {
         $address = $socket->getSockName();
         $port = substr($address, strrpos($address, ':') + 1);
 
+        $this->setExpectedException('Exception');
         $this->factory->createListen($port);
     }
 
@@ -488,15 +491,19 @@ class FactoryTest extends TestCase
         $this->fail('Creating socket for invalid scheme should fail');
     }
 
-    public function setExpectedException($exception, $message = '', $code = 0)
+    public function setExpectedException($exception, $message = null, $code = null)
     {
         if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
             $this->expectException($exception);
             if ($message !== null) {
                 $this->expectExceptionMessage($message);
             }
-            $this->expectExceptionCode($code);
+            if ($code !== null) {
+                $this->expectExceptionCode($code);
+            }
         } else {
+            // legacy PHPUnit 4 - PHPUnit 5.1
             parent::setExpectedException($exception, $message, $code);
         }
     }

--- a/tests/SocketTest.php
+++ b/tests/SocketTest.php
@@ -12,7 +12,10 @@ class SocketTest extends TestCase
      */
     protected $factory;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpFactory()
     {
         $this->factory = new Factory();
     }


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.