### PR TITLE
Drop legacy HHVM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ jobs:
     - php: 7.2
     - php: 7.3
     - php: 7.4
-    - php: hhvm-3.18
-      install: composer require phpunit/phpunit:^5 --dev
     - name: "Windows"
       os: windows
       language: shell # no built-in php support
@@ -27,7 +25,6 @@ jobs:
         - php -r "file_put_contents(php_ini_loaded_file(),'extension_dir=ext'.PHP_EOL,FILE_APPEND);"
         - php -r "file_put_contents(php_ini_loaded_file(),'extension=sockets'.PHP_EOL,FILE_APPEND);"
   allow_failures:
-    - php: hhvm-3.18
     - os: windows
 
 install:

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
 extensions besides `ext-sockets` and supports running on legacy PHP 5.3 through
-current PHP 7+ and HHVM.
+current PHP 7+.
 It's *highly recommended to use PHP 7+* for this project.
 
 ## Tests

--- a/tests/SocketTest.php
+++ b/tests/SocketTest.php
@@ -224,8 +224,7 @@ class SocketTest extends TestCase
             $server->accept();
             $this->fail('accept() MUST throw an exception');
         } catch (Exception $e) {
-            // code should usually be SOCKET_EAGAIN, hhvm uses SOCKET_EBADF, so let's play it safe
-            $this->assertNotEquals(0, $e->getCode());
+            $this->assertEquals(SOCKET_EWOULDBLOCK, $e->getCode());
         }
     }
 


### PR DESCRIPTION
HHVM does not support PHP anymore and regularly causes our builds to fail, so no reason to keep legacy HHVM support around anymore.