### PR TITLE
Fix strict types for `socket_select()` without timeout on PHP 8+

### DIFF
--- a/src/Socket.php
+++ b/src/Socket.php
@@ -313,7 +313,7 @@ class Socket
      */
     public function selectRead($sec = 0)
     {
-        $usec = $sec === null ? null : (int) (($sec - floor($sec)) * 1000000);
+        $usec = $sec === null ? 0 : (int) (($sec - floor($sec)) * 1000000);
         $r = array($this->resource);
         $n = null;
         $ret = @socket_select($r, $n, $n, $sec === null ? null : (int) $sec, $usec);
@@ -334,7 +334,7 @@ class Socket
      */
     public function selectWrite($sec = 0)
     {
-        $usec = $sec === null ? null : (int) (($sec - floor($sec)) * 1000000);
+        $usec = $sec === null ? 0 : (int) (($sec - floor($sec)) * 1000000);
         $w = array($this->resource);
         $n = null;
         $ret = @socket_select($n, $w, $n, $sec === null ? null : (int) $sec, $usec);


### PR DESCRIPTION
Builds on top of #61, #63, #67
See also https://github.com/phpstan/phpstan-src/pull/591 and https://github.com/phpstan/phpstan-src/pull/385 (via #56) (interestingly, `socket_select()` and `stream_select()` have different types only for the `$microseconds` parameter)